### PR TITLE
fix(ci): mint the App token from the client ID, not the app ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -87,9 +87,9 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Every run in this repo currently logs a deprecation warning, because
`actions/create-github-app-token` deprecated its `app-id` input in v3.2.0 in
favour of `client-id`.

Being precise about what is deprecated, because the loose version keeps getting
repeated: the numeric App ID is NOT deprecated at the platform level and still
works. The INPUT is. GitHub separately recommends the client ID because
compatibility with future App APIs depends on it - the app ID is not globally
unique and the app name is not immutable.

`GH_APP_CLIENT_ID` is an org VARIABLE, not a secret. A client ID is not sensitive, and
putting it in secrets only makes a log harder to read. It was derived from the
same app's private key by hyperi-infra `scripts/github-app-client-ids.py`, so it
pairs with `GH_APP_PRIVATE_KEY` by construction rather than by coincidence.

The action was already SHA-pinned at v3.2.0, so only the input changes.

Done when a run log shows no `app-id` deprecation warning.

Part of a fleet sweep - hyperi-io/hyperi-ci#100.
